### PR TITLE
fix the if statement for screenshot to reflect the correct path

### DIFF
--- a/AppiumForMac/Server/AfMHTTPConnection.m
+++ b/AppiumForMac/Server/AfMHTTPConnection.m
@@ -123,7 +123,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_VERBOSE;
     // /session/:sessionId/execute_async
 
     // GET /session/:sessionId/screenshot
-    if ([path isEqualToString:@"/screenshot"] && [method isEqualToString:@"GET"])
+    if (pathComponents.count == 3 && [[pathComponents objectAtIndex:0] isEqualToString:@"session"] && [[pathComponents objectAtIndex:2] isEqualToString:@"screenshot"] && [method isEqualToString:@"GET"])
 	{
         return [SERVER.handler getScreenshot:path];
 	}


### PR DESCRIPTION
I was using the screenshot function and got UnsupportedCommandException, so I checked the server code and found the if statement for screenshot in AfMHTTPConnection.m does not reflect its true path. I changed it and it worked for me.
