### PR TITLE
fix issue #9, use png format for screenshot

### DIFF
--- a/AppiumForMac/Server/Handlers/AfMHandlers.m
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.m
@@ -265,7 +265,13 @@
     {
         NSArray *objectsToPaste = [pasteboard readObjectsForClasses:classArray options:options];
         NSImage *image = [objectsToPaste objectAtIndex:0];
-        NSString *base64Image = [[image TIFFRepresentation] base64EncodedString];
+        CGImageRef cgRef = [image CGImageForProposedRect:NULL
+                                                 context:nil
+                                                   hints:nil];
+        NSBitmapImageRep *newRep = [[NSBitmapImageRep alloc] initWithCGImage:cgRef];
+        [newRep setSize:[image size]];
+        NSData *pngData = [newRep representationUsingType:NSPNGFileType properties:nil];
+        NSString *base64Image = [pngData base64EncodedString];
         return [self respondWithJson:base64Image status:kAfMStatusCodeSuccess session:[Utility getSessionIDFromPath:path]];
     }
     else


### PR DESCRIPTION
file size reduced from 15mb to 900k, when use filecopy method to save it on disk in a maven project.
