### PR TITLE
take screen shot of the app window only, instead of the whole screen.

### DIFF
--- a/AppiumForMac/Server/Controller/AfMSessionController.h
+++ b/AppiumForMac/Server/Controller/AfMSessionController.h
@@ -44,6 +44,7 @@
 -(void) sendKeys:(NSString*)keys;
 -(void) sendKeys:(NSString*)keys toElement:(PFUIElement*)element;
 -(PFUIElement*) windowForHandle:(NSString*)windowHandle;
+-(NSDictionary*) frontmostAppWindowInfo;
 -(GDataXMLDocument*)xmlPageSource;
 -(GDataXMLDocument*)xmlPageSourceFromElement:(PFUIElement*)rootUIElement pathMap:(NSMutableDictionary*)pathMap;
 

--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -225,6 +225,19 @@
 	return [windows objectAtIndex:windowIndex];
 }
 
+-(NSDictionary *) frontmostAppWindowInfo{
+    
+    NSArray *windowList = (__bridge NSArray *) CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+    for (NSDictionary *dictionary in windowList) {
+        NSNumber *windowLayer = [dictionary objectForKey:@"kCGWindowLayer"];
+        NSNumber *windowOwnerPID  = [dictionary objectForKey:@"kCGWindowOwnerPID"];
+        if (([windowLayer isEqualToNumber:[NSNumber numberWithInt:0]]) && ([windowOwnerPID  isEqualToNumber:[NSNumber numberWithInteger:[self pidForProcessName:[self currentProcessName]]]])) {
+            return dictionary;
+        }
+    }
+    return nil;
+}
+
 -(GDataXMLDocument*)xmlPageSource
 {
 	return [self xmlPageSourceFromElement:nil pathMap:nil];

--- a/AppiumForMac/Server/Handlers/AfMHandlers.h
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.h
@@ -5,7 +5,7 @@
 //  Created by Dan Cuellar on 7/28/13.
 //  Copyright (c) 2013 Appium. All rights reserved.
 //
-
+#import <Cocoa/Cocoa.h>
 #import <Foundation/Foundation.h>
 #import "AppiumMacHTTPJSONResponse.h"
 #import "AfMSessionController.h"


### PR DESCRIPTION
fix issue #12 .
basically this change does a few things:
1. get a list of on-sreen, non-desktopElement windows
2. get the pid of the app
3. get the first window from the list that matches the pid.
(Even you open multiple test app, the lastest one launched by appium
will be used for screenshot)
4. get the windowID of that window
5. take screenshot
used current ultility methods and Quartz Window Service methods.

NOTE: this takes a clean screenshot of the app window only but you also lose the menu from the screenshot because it is in another window.
