### PR TITLE
Code for the demo at SeConf 2017 Austin TX. 

### DIFF
--- a/AppiumForMac.xcodeproj/project.pbxproj
+++ b/AppiumForMac.xcodeproj/project.pbxproj
@@ -62,10 +62,20 @@
 		36D203E217A5DE7000011A3A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36D203E117A5DE7000011A3A /* Security.framework */; };
 		36D7968A17BF1A4B00D1B81E /* PFAssistive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36D7968917BF1A4B00D1B81E /* PFAssistive.framework */; };
 		4F31407119662998009BDF33 /* PFAssistive.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 36D7968917BF1A4B00D1B81E /* PFAssistive.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		C14989BC1E917BF5007D3500 /* NotesWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = C14989B91E917BF5007D3500 /* NotesWindow.xib */; };
+		C14989BD1E917BF5007D3500 /* NotesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C14989BB1E917BF5007D3500 /* NotesWindowController.m */; };
 		C14EAB301DB452630010E210 /* KeystrokesAndKeyCodes.m in Sources */ = {isa = PBXBuildFile; fileRef = C14EAB2E1DB452630010E210 /* KeystrokesAndKeyCodes.m */; };
 		C14EAB311DB452630010E210 /* KeystrokesAndKeyCodes.m in Sources */ = {isa = PBXBuildFile; fileRef = C14EAB2E1DB452630010E210 /* KeystrokesAndKeyCodes.m */; };
 		C14EAB331DB453220010E210 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C14EAB321DB453220010E210 /* Carbon.framework */; };
 		C14EAB341DB453220010E210 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C14EAB321DB453220010E210 /* Carbon.framework */; };
+		C1A391551DE93AD300B96CAC /* AXPathUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = C1A391541DE93AD300B96CAC /* AXPathUtility.m */; };
+		C1C3A60B1E91A774002246DB /* calculator.py in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6041E91A774002246DB /* calculator.py */; };
+		C1C3A60C1E91A774002246DB /* dock_demo.pyc in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6051E91A774002246DB /* dock_demo.pyc */; };
+		C1C3A60D1E91A774002246DB /* ios-sim.py in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6061E91A774002246DB /* ios-sim.py */; };
+		C1C3A60E1E91A774002246DB /* safari.py in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6071E91A774002246DB /* safari.py */; };
+		C1C3A60F1E91A774002246DB /* textedit.py in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6081E91A774002246DB /* textedit.py */; };
+		C1C3A6101E91A774002246DB /* utilities.py in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A6091E91A774002246DB /* utilities.py */; };
+		C1C3A6111E91A774002246DB /* utilities.pyc in Resources */ = {isa = PBXBuildFile; fileRef = C1C3A60A1E91A774002246DB /* utilities.pyc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,9 +203,22 @@
 		36D203DE17A5D8B900011A3A /* AfMHTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AfMHTTPConnection.m; sourceTree = "<group>"; };
 		36D203E117A5DE7000011A3A /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		36D7968917BF1A4B00D1B81E /* PFAssistive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PFAssistive.framework; path = Frameworks/PFAssistive.framework; sourceTree = "<group>"; };
+		C14989B91E917BF5007D3500 /* NotesWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NotesWindow.xib; sourceTree = "<group>"; };
+		C14989BA1E917BF5007D3500 /* NotesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotesWindowController.h; sourceTree = "<group>"; };
+		C14989BB1E917BF5007D3500 /* NotesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotesWindowController.m; sourceTree = "<group>"; };
 		C14EAB2E1DB452630010E210 /* KeystrokesAndKeyCodes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeystrokesAndKeyCodes.m; sourceTree = "<group>"; };
 		C14EAB2F1DB452630010E210 /* KeystrokesAndKeyCodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeystrokesAndKeyCodes.h; sourceTree = "<group>"; };
 		C14EAB321DB453220010E210 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		C1A391531DE93AD300B96CAC /* AXPathUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AXPathUtility.h; sourceTree = "<group>"; };
+		C1A391541DE93AD300B96CAC /* AXPathUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AXPathUtility.m; sourceTree = "<group>"; };
+		C1C3A6041E91A774002246DB /* calculator.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = calculator.py; sourceTree = "<group>"; };
+		C1C3A6051E91A774002246DB /* dock_demo.pyc */ = {isa = PBXFileReference; lastKnownFileType = file; path = dock_demo.pyc; sourceTree = "<group>"; };
+		C1C3A6061E91A774002246DB /* ios-sim.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "ios-sim.py"; sourceTree = "<group>"; };
+		C1C3A6071E91A774002246DB /* safari.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = safari.py; sourceTree = "<group>"; };
+		C1C3A6081E91A774002246DB /* textedit.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = textedit.py; sourceTree = "<group>"; };
+		C1C3A6091E91A774002246DB /* utilities.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = utilities.py; sourceTree = "<group>"; };
+		C1C3A60A1E91A774002246DB /* utilities.pyc */ = {isa = PBXFileReference; lastKnownFileType = file; path = utilities.pyc; sourceTree = "<group>"; };
+		C1C3A6121E91A7CB002246DB /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,6 +257,8 @@
 				361034AB17A4990F00DB79AA /* AppiumForMacTests */,
 				3610348717A4990E00DB79AA /* Frameworks */,
 				3610348617A4990E00DB79AA /* Products */,
+				C1C3A6031E91A774002246DB /* examples */,
+				C1C3A6121E91A7CB002246DB /* README.md */,
 			);
 			sourceTree = "<group>";
 		};
@@ -349,6 +374,11 @@
 				3621D0BD17AEC31100E97463 /* NSString+Extensions.m */,
 				3614DE1617A58F2600853962 /* Utility.h */,
 				3614DE1717A58F2600853962 /* Utility.m */,
+				C1A391531DE93AD300B96CAC /* AXPathUtility.h */,
+				C1A391541DE93AD300B96CAC /* AXPathUtility.m */,
+				C14989B91E917BF5007D3500 /* NotesWindow.xib */,
+				C14989BA1E917BF5007D3500 /* NotesWindowController.h */,
+				C14989BB1E917BF5007D3500 /* NotesWindowController.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -519,6 +549,20 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		C1C3A6031E91A774002246DB /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				C1C3A6041E91A774002246DB /* calculator.py */,
+				C1C3A6051E91A774002246DB /* dock_demo.pyc */,
+				C1C3A6061E91A774002246DB /* ios-sim.py */,
+				C1C3A6071E91A774002246DB /* safari.py */,
+				C1C3A6081E91A774002246DB /* textedit.py */,
+				C1C3A6091E91A774002246DB /* utilities.py */,
+				C1C3A60A1E91A774002246DB /* utilities.pyc */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -593,12 +637,20 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1C3A60C1E91A774002246DB /* dock_demo.pyc in Resources */,
+				C1C3A60D1E91A774002246DB /* ios-sim.py in Resources */,
+				C1C3A60E1E91A774002246DB /* safari.py in Resources */,
 				3610349317A4990E00DB79AA /* InfoPlist.strings in Resources */,
 				3610349917A4990E00DB79AA /* Credits.rtf in Resources */,
 				3610349F17A4990F00DB79AA /* MainMenu.xib in Resources */,
+				C1C3A6111E91A774002246DB /* utilities.pyc in Resources */,
+				C1C3A60F1E91A774002246DB /* textedit.py in Resources */,
 				36D203D117A5D6B300011A3A /* AboutCocoaAsyncSocket.txt in Resources */,
 				36D203D317A5D6B300011A3A /* AboutCocoaLumberjack.txt in Resources */,
+				C1C3A6101E91A774002246DB /* utilities.py in Resources */,
+				C1C3A60B1E91A774002246DB /* calculator.py in Resources */,
 				36D203DB17A5D6B300011A3A /* README.txt in Resources */,
+				C14989BC1E917BF5007D3500 /* NotesWindow.xib in Resources */,
 				3623981317AFF9C700DE5719 /* appium-for-mac.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +686,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C14989BD1E917BF5007D3500 /* NotesWindowController.m in Sources */,
 				3610349517A4990E00DB79AA /* main.m in Sources */,
 				3610349C17A4990E00DB79AA /* AppiumForMacAppDelegate.m in Sources */,
 				3614DE1017A5887700853962 /* AfMHTTPServer.m in Sources */,
@@ -645,6 +698,7 @@
 				36D203C317A5D6B300011A3A /* DDRange.m in Sources */,
 				C14EAB301DB452630010E210 /* KeystrokesAndKeyCodes.m in Sources */,
 				36D203C417A5D6B300011A3A /* HTTPAuthenticationRequest.m in Sources */,
+				C1A391551DE93AD300B96CAC /* AXPathUtility.m in Sources */,
 				36D203C517A5D6B300011A3A /* HTTPConnection.m in Sources */,
 				36D203C617A5D6B300011A3A /* HTTPMessage.m in Sources */,
 				36D203C717A5D6B300011A3A /* HTTPServer.m in Sources */,

--- a/AppiumForMac/AppiumForMacAppDelegate.h
+++ b/AppiumForMac/AppiumForMacAppDelegate.h
@@ -9,11 +9,18 @@
 #import <Cocoa/Cocoa.h>
 #import "AfMHTTPServer.h"
 
+#define AFMFnKeyTriggerNotification @"AFMFnKeyTriggerNotification"
+
 #define AFM_SERVER [(AppiumForMacAppDelegate*)[[NSApplication sharedApplication] delegate] afmHTTPServer]
+
+@class NotesWindowController;
 
 @interface AppiumForMacAppDelegate : NSObject <NSApplicationDelegate>
 
 @property (assign) IBOutlet NSWindow *window;
+@property NotesWindowController *notesWC;
 @property AfMHTTPServer *afmHTTPServer;
+
+- (IBAction)showNotesWindow:(id)sender;
 
 @end

--- a/AppiumForMac/AppiumForMacAppDelegate.m
+++ b/AppiumForMac/AppiumForMacAppDelegate.m
@@ -10,16 +10,25 @@
 
 #import "AfMHTTPServer.h"
 #import "AfMHTTPConnection.h"
+#import "AXPathUtility.h"
 #import "HTTPServer.h"
 #import "DDLog.h"
 #import "DDTTYLogger.h"
+#import "NotesWindowController.h"
 #import "Utility.h"
 
 static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 
+@interface AppiumForMacAppDelegate ()
+@property id fnKeyGlobalMonitor;
+@property id fnKeyLocalMonitor;
+@property id fnKeyTimer;
+@property AXPathUtility *axPathUtility;
+@end
+
 @implementation AppiumForMacAppDelegate
 
--(void) applicationDidFinishLaunching:(NSNotification *)aNotification
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
     self.afmHTTPServer = [[AfMHTTPServer alloc] init];
@@ -32,6 +41,116 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	{
 		DDLogError(@"Error starting HTTP Server: %@", error);
 	}
+    
+    self.notesWC = [[NotesWindowController alloc] initWithWindowNibName:@"NotesWindow"];
+    BOOL shouldShowNotesWindow = [[NSUserDefaults standardUserDefaults] boolForKey:kShowNotesWindowOnLaunchKey];
+    if (shouldShowNotesWindow) {
+        [self showNotesWindow:nil];
+    }
+    self.axPathUtility = [[AXPathUtility alloc] init];
+    [self startMonitoring];
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender;
+{
+    BOOL notesWindowShowing = self.notesWC.window.visible;
+    [[NSUserDefaults standardUserDefaults] setBool:notesWindowShowing forKey:kShowNotesWindowOnLaunchKey];
+    
+    return NSTerminateNow;
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification
+{
+    [self stopMonitoring];
+}
+
+- (void)startMonitoring
+{
+    [self addGlobalMonitorForFnKey];
+    [self addLocalMonitorForFnKey];
+}
+
+- (void)stopMonitoring
+{
+    [self stopFnKeyTimer];
+    [self removeMonitors];
+}
+
+// Press the fn key for a second to take a snapshot of the AXPath under the mouse.
+// It will also cancel any existing WebDriver sessions.
+- (void)addGlobalMonitorForFnKey
+{
+    self.fnKeyGlobalMonitor = [NSEvent addGlobalMonitorForEventsMatchingMask:NSFlagsChangedMask handler:^(NSEvent *event) {
+        NSEventModifierFlags newFlags = [NSEvent modifierFlags];
+        
+        if (newFlags & NSFunctionKeyMask) {
+            // Start a timer to detect how long the function key is held down.
+            [self startFnKeyTimer];
+        } else {
+            // The function key is no longer held down. Disable the timer.
+            [self stopFnKeyTimer];
+        }
+    }];
+}
+
+// Press the fn key for a few seconds to take a snapshot of the AXPath under the mouse.
+// It will also cancel any existing WebDriver sessions.
+- (void)addLocalMonitorForFnKey
+{
+    self.fnKeyLocalMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSFlagsChangedMask handler:^NSEvent *(NSEvent *event) {
+        NSEventModifierFlags newFlags = [NSEvent modifierFlags];
+        
+        if (newFlags & NSFunctionKeyMask) {
+            // Start a timer to detect how long the function key is held down.
+            [self startFnKeyTimer];
+        } else {
+            // The function key is no longer held down. Disable the timer.
+            [self stopFnKeyTimer];
+        }
+        return event;
+    }];
+}
+
+- (void)removeMonitors
+{
+    if (self.fnKeyGlobalMonitor) {
+        [NSEvent removeMonitor:self.fnKeyGlobalMonitor];
+        self.fnKeyGlobalMonitor = nil;
+    }
+    if (self.fnKeyLocalMonitor) {
+        [NSEvent removeMonitor:self.fnKeyLocalMonitor];
+        self.fnKeyLocalMonitor = nil;
+    }
+}
+
+- (void)startFnKeyTimer
+{
+    [self stopFnKeyTimer];
+    NSTimeInterval const kTriggerDelay = 1.0;
+    //self.fnKeyTimer = [NSTimer scheduledTimerWithTimeInterval:kTriggerDelay target:self selector:@selector(fnKeyTimer:) userInfo:nil repeats:NO];
+    
+    dispatch_time_t fnKeyDelay = dispatch_time(DISPATCH_TIME_NOW, kTriggerDelay * NSEC_PER_SEC);
+    dispatch_after(fnKeyDelay, dispatch_get_main_queue(), ^{ @autoreleasepool {
+        [self fnKeyTimer:nil];
+    }});
+}
+
+- (void)stopFnKeyTimer
+{
+    if ([self.fnKeyTimer isValid]) {
+        [self.fnKeyTimer invalidate];
+    }
+    self.fnKeyTimer = nil;
+}
+
+- (void)fnKeyTimer:(NSTimer *)timer
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:AFMFnKeyTriggerNotification object:nil];
+}
+
+- (IBAction)showNotesWindow:(id)sender
+{
+    [[self notesWC] showWindow:nil];
 }
 
 @end

--- a/AppiumForMac/Server/Controller/AfMElementLocator.m
+++ b/AppiumForMac/Server/Controller/AfMElementLocator.m
@@ -25,8 +25,8 @@
 		self.session = session;
 		self.strategy = strategy;
 		self.value = value;
-        if ([self.value rangeOfString:@"/AXApplication"].location != 0) {
-            NSLog(@"AfMElementLocator initWithSession self.value is not AbsoluteAXPath: %@", self.value);
+        if (strategy == AppiumMacLocatoryStrategyXPath && [self.value rangeOfString:@"/AXApplication"].location != 0) {
+            NSLog(@"AfMElementLocator initWithSession (AppiumMacLocatoryStrategyXPath) self.value is not AbsoluteAXPath: %@", self.value);
         }
     }
     return self;
@@ -100,7 +100,8 @@
         }
         
         // VERY RESTRICTIVE - Remove me to handle partial XPaths (which can be very, very slow).
-        if (YES) {
+        BOOL const requireAbsoluteAXPath = YES;
+        if (requireAbsoluteAXPath) {
             NSLog(@"findUsingBaseUIElement XPath was not AbsoluteAXPath: %@", self.value);
             return nil;
         }

--- a/AppiumForMac/Server/Handlers/AfMHandlers.h
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.h
@@ -54,10 +54,7 @@
 // POST /session/:sessionId/forward
 // POST /session/:sessionId/back
 // POST /session/:sessionId/refresh
-
 // POST /session/:sessionId/execute
-- (AppiumMacHTTPJSONResponse *)post_execute:(NSString*)path data:(NSData*)postData;
-
 // POST /session/:sessionId/execute_async
 
 // GET /session/:sessionId/screenshot
@@ -88,8 +85,13 @@
 - (AppiumMacHTTPJSONResponse *)get_window_position:(NSString*)path;
 
 // POST /session/:sessionId/window/:windowHandle/maximize
+
 // GET /session/:sessionId/cookie
+- (AppiumMacHTTPJSONResponse *)get_cookie:(NSString*)path;
+
 // POST /session/:sessionId/cookie
+- (AppiumMacHTTPJSONResponse *)post_cookie:(NSString*)path data:(NSData*)postData;
+
 // DELETE /session/:sessionId/cookie
 // DELETE /session/:sessionId/cookie/:name
 

--- a/AppiumForMac/Server/Responses/AfMStatusCodes.h
+++ b/AppiumForMac/Server/Responses/AfMStatusCodes.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSUInteger, AFMStatusCode) {
     kAfMStatusCodeInvalidSelector = 32,
     kAfMStatusCodeSessionNotCreatedException = 33,
     kAfMStatusCodeMoveTargetOutOfBounds = 34,
+    kAfMStatusCodeInvalidArgument = 35,
 };
 
 FOUNDATION_EXPORT NSString * const kAfMStatusCodeMessages[];

--- a/AppiumForMac/Utility/AXPathUtility.h
+++ b/AppiumForMac/Utility/AXPathUtility.h
@@ -1,0 +1,18 @@
+//
+//  AXPathUtility.h
+//  AppiumForMac
+//
+//  Created by Russell, Stuart on 11/25/16.
+//  Copyright © 2016 Appium. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Carbon/Carbon.h>
+
+extern NSString * const kNewTextPostedNotification;
+
+@interface AXPathUtility : NSObject
+
+- (NSString *)axPathAtMousePosition:(HIPoint)mousePosition offsetPercent:(NSSize *)offsetPercent;
+
+@end

--- a/AppiumForMac/Utility/AXPathUtility.m
+++ b/AppiumForMac/Utility/AXPathUtility.m
@@ -1,0 +1,280 @@
+//
+//  AXPathUtility.m
+//  AppiumForMac
+//
+//  Created by Stuart Russell at Intuit, Inc. on 11/25/16.
+//  Copyright © 2016 Appium. All rights reserved.
+//
+
+#import <AppKit/AppKit.h>
+#import <PFAssistive/PFAssistive.h>
+
+#import "AXPathUtility.h"
+#import "AppiumForMacAppDelegate.h"
+
+NSUInteger const kMaximumTitleLength = 256;
+NSString * const kNewTextPostedNotification = @"NewTextPosted";
+
+@implementation AXPathUtility
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(fnKeyTrigger:) name:AFMFnKeyTriggerNotification object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)fnKeyTrigger:(NSNotification *)notification
+{
+    HIPoint currentMousePosition = [self getMousePosition];
+    NSSize offset;
+    NSString *axPath = [self axPathAtMousePosition:currentMousePosition offsetPercent:&offset];
+    NSLog(@"axPath:\n%@", axPath);
+    if (axPath && axPath.length) {
+        // Add surrounding double quotes to the path string.
+        NSString *quotedAXPath = [NSString stringWithFormat:@"\"%@\"", axPath];
+        
+        // Copy the axPath to the clipboard with a couple of blank lines.
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        [pasteboard clearContents];
+        [pasteboard writeObjects:@[quotedAXPath]];
+//        [pasteboard writeObjects:[quotedAXPath arrayByAddingObject:@"\n"]];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:kNewTextPostedNotification object:quotedAXPath];
+        
+        // Bounce the dock icon once.
+        NSInteger rq = [NSApp requestUserAttention:NSInformationalRequest];
+        [NSApp cancelUserAttentionRequest:rq];
+    }
+}
+
+// Given a screen-based point, returns an absolute axPath
+- (NSString *)axPathAtMousePosition:(HIPoint)mousePosition offsetPercent:(NSSize *)offsetPercent
+{
+    NSError *error = nil;
+    PFUIElement *hitElement = [PFUIElement elementAtPoint:mousePosition withDelegate:nil error:&error];
+    if (!hitElement) {
+        // No element under the mouse? How odd.
+        NSLog(@"axPathAtMousePosition ERROR no hitElement at mousePosition: %@ NSError:%@", NSStringFromPoint(mousePosition), error);
+        return nil;
+    }
+    
+    // Get the offsetPercent as an HISize. This can be used to calculate the offset for the moveto command. 
+    if (offsetPercent != nil) {
+        *offsetPercent = NSMakeSize(0.0, 0.0);
+        NSValue *value = [hitElement valueForAttribute:NSAccessibilityPositionAttribute];
+        HIPoint elementUpperLeftCorner = [value pointValue];
+        HIPoint absoluteOffset = NSMakePoint(mousePosition.x - elementUpperLeftCorner.x, mousePosition.y - elementUpperLeftCorner.y);
+        value = [hitElement valueForAttribute:NSAccessibilitySizeAttribute];
+        HISize elementSize = [value sizeValue];
+        *offsetPercent = NSMakeSize(absoluteOffset.x / elementSize.width, absoluteOffset.y / elementSize.height);
+        
+        //        NSLog(@"axPathAtMousePosition elementUpperLeftCorner: %@", NSStringFromPoint(elementUpperLeftCorner));
+        //        NSLog(@"axPathAtMousePosition elementSize           : %@", NSStringFromSize(elementSize));
+        //        NSLog(@"axPathAtMousePosition offsetPercent         : %@", NSStringFromSize(*offsetPercent));
+    }
+    
+    // Construct an axPath
+    NSMutableString *axPath = [@"" mutableCopy];
+    
+    NSArray *hitPath = [hitElement path];
+    for (PFUIElement *element in hitPath) {
+        //        NSLog(@"hitTestAXElement: %@", [element debugDescription]);
+        
+        NSString *role = [element AXRole];
+        NSString *title = [element AXTitle];
+        id value = [element AXValue];
+        
+        // Dock icon contextual menus require special handling with a different method.
+        if ([role isEqualToString:@"AXApplication"]) {
+            if (title && [title isEqualToString:@"Dock"] && [[hitElement AXRole] isEqualToString:@"AXMenuItem"]) {
+                NSString *dockAXPath = [self axPathForDockAXMenuItem:hitElement];
+                if (dockAXPath && dockAXPath.length) {
+                    return dockAXPath;
+                }
+            }
+        }
+        
+        // Check if the item is child element that can be accessed with an index in the xPath.
+        BOOL elementHasIndex = NO;
+        NSUInteger index = NSNotFound;
+        PFUIElement *parent = [element AXParent];
+        if (parent) {
+            NSArray *siblings = [parent AXChildren];
+            if (siblings) {
+                // This next method call shows how PFUIElement is a very nice API.
+                index = [element indexAmongLikeElementsInArray:siblings];
+                if (index != NSNotFound) {
+                    elementHasIndex = YES;
+                }
+            }
+        }
+        
+        [axPath appendString:@"/"];
+        if (role) {
+            [axPath appendString:role];
+        } else {
+            NSLog(@"axPathAtMousePosition ERROR role is nil for element:%@ partialAXPath:%@", hitElement, axPath);
+        }
+        
+        // Add a predicate to the role.
+        // Add as many interesting attributes as we can detect, that have non-nil values. The scripter can edit.
+        // If no interesting attributes available, if the element is indexed, use the index integer; 
+        // otherwise use the (sub)role string without a predicate.
+        NSMutableArray *attributeComparisons = [@[] mutableCopy];
+        
+        if (title && title.length > 0 && title.length <= kMaximumTitleLength) {
+            [attributeComparisons addObject:[NSString stringWithFormat:@"@AXTitle='%@'", title]];
+        }
+        if (value && [value isKindOfClass:[NSString class]] && [value length] > 0 && [value length] <= kMaximumTitleLength) {
+            [attributeComparisons addObject:[NSString stringWithFormat:@"@AXValue='%@'", value]];
+        }
+        
+        NSString *attrVal;
+        NSArray *attrNames = @[@"AXIdentifier", @"AXDOMIdentifier", @"AXSubrole"];
+        for (NSString *attrName in attrNames) {
+            attrVal = [element valueForAttribute:attrName];
+            if (attrVal && [attrVal isKindOfClass:[NSString class]] && [attrVal length] > 0 && [attrVal length] <= kMaximumTitleLength) {
+                [attributeComparisons addObject:[NSString stringWithFormat:@"@%@='%@'", attrName, attrVal]];
+            }
+        }
+        
+        if ([attributeComparisons count]) {
+            NSMutableString *predStr = [@"" mutableCopy];
+            
+            [predStr appendString:attributeComparisons[0]];
+            for (int i = 1; i < [attributeComparisons count]; i++) {
+                [predStr appendString:@" and "];
+                [predStr appendFormat:@"%@", attributeComparisons[i]];
+            }
+            
+            [axPath appendFormat:@"[%@]", predStr];
+        } else if (elementHasIndex) {
+            [axPath appendFormat:@"[%lu]", index];
+        }
+    }
+    
+    return axPath;
+}
+
+// Fix Dock item contextual menu Accessibility tree, which has different paths for going up and going down. 
+// One path, constructed child to parent (see also Accessibility Inspector):
+//      /AXApplication[@AXTitle='Dock']/AXMenu/AXMenuItem[@AXTitle='Hide']
+//      In this case AXMenu is in the AXChildren array of the AXApplication.
+// But the actual path does not go through the children array:
+//      /AXApplication[@AXTitle='Dock']/AXFocusedUIElement/AXMenuItem[@AXTitle='Hide']
+//      The AXFocusedUIElement is an AXMenu which is NOT in the AXChildren array.
+// /AXApplication[@AXTitle='Dock']/AXFocusedUIElement/AXMenuItem[@Title='Show In Finder']
+// /AXApplication[@AXTitle='Dock']/AXFocusedUIElement/AXMenuItem[@Title='Options']/AXMenu/AXMenuItem[@Title='Show In Finder']
+// (indexes can vary per application and per application state e.g. running or not, active/non-active/hidden)
+- (NSString *)axPathForDockAXMenuItem:(PFUIElement *)element
+{
+    NSLog(@"axPathForDockAXMenuItem element:%@", element); 
+    
+    if (!element || ![element isRole:@"AXMenuItem"]) {
+        return nil;
+    }
+    
+    //  TODO: Pure indexes are problematic, so use strings. For non-US Engish locales, this may not work.
+    NSMutableString *axPath = [@"" mutableCopy];
+        
+    // Check if the menu item is a submenu axPath variables for submenu.
+    BOOL isSubmenu = NO;
+    PFUIElement *parent = [element AXParent];       // AXMenu, which may or may not also be AXFocusedUIElement
+    PFUIElement *grandParent = [parent AXParent];   // AXApplication or AXMenuItem
+    PFApplicationUIElement *dockApp;
+    if ([grandParent isRole:@"AXApplication"]) {
+        isSubmenu = NO;
+        dockApp = (PFApplicationUIElement *)grandParent;
+    } else if ([grandParent isRole:@"AXMenuItem"]) {
+        isSubmenu = YES;
+        dockApp = (PFApplicationUIElement *)[[grandParent AXParent] AXParent];
+    }
+    
+    NSLog(@"dockApp AXChildren:\n%@", [dockApp AXChildren]);
+    NSLog(@"dockApp AXFocusedUIElement:\n%@", [dockApp AXFocusedUIElement]);
+    // Big assumption: the Dock will always be named "Dock".
+    [axPath appendString:@"/AXApplication[@AXTitle='Dock']"];
+    
+    // Build the axPath going through the Dock item for this contextual menu.
+    // Dock items are accessed through an AXList in the Dock's AXChildren.
+    // Assumption: never more than one Dock item with a non-nil AXShownMenuUIElement;
+    NSArray *dockChildren = [dockApp AXChildren];
+    NSUInteger indexOfAXList = [dockChildren indexOfObjectWithOptions:NSEnumerationConcurrent passingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isKindOfClass:[PFUIElement class]] && [obj isRole:@"AXList"]) {
+            *stop = YES;
+            return YES;
+        }
+        return NO;
+    }];
+    PFUIElement *dockAXList = [dockChildren objectAtIndex:indexOfAXList];
+    NSArray *dockItemList = [dockAXList AXChildren];
+    NSUInteger indexOfItemWithMenu = [dockItemList indexOfObjectWithOptions:NSEnumerationConcurrent passingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isKindOfClass:[PFUIElement class]] && [obj isRole:@"AXDockItem"] && [obj valueForAttribute:@"AXShownMenuUIElement"] != nil) {
+            *stop = YES;
+            return YES;
+        }
+        return NO;
+    }];
+    PFUIElement *dockItemWithMenu = [dockItemList objectAtIndex:indexOfItemWithMenu];
+    // Bug in the Dock.app: AXShownMenuUIElement should be a UI Element but can be returned as an array.
+    [axPath appendFormat:@"/AXList[0]/AXDockItem[@AXTitle='%@']/AXMenu[0]", [dockItemWithMenu AXTitle]];
+    
+    if (isSubmenu) {
+        // Add the title/index of the top level menu item, which is no longer included in the child array,
+        // and is no longer AXFocusedUIElement. It can only be found if you have the menu item,
+        // then go upwards through the parent menus.
+        
+        NSString *grandTitle = [grandParent AXTitle];
+        NSUInteger grandIndex = 0;
+        PFUIElement *greatGrandParent = [grandParent AXParent];   // AXMenu which is also AXFocusedUIElement
+        NSArray *grandSiblings = [greatGrandParent AXChildren];
+        if (grandSiblings) {
+            grandIndex = [grandParent indexAmongLikeElementsInArray:grandSiblings];
+        }
+        if (grandTitle && grandTitle.length > 0) {
+            [axPath appendFormat:@"/AXMenuItem[@AXTitle='%@']/AXMenu[0]", grandTitle];
+        } 
+        else if (grandIndex != NSNotFound) {
+            [axPath appendFormat:@"/AXMenuItem[%lu]/AXMenu[0]", grandIndex];
+        }
+    } else {
+        // This is the title 
+    }
+    
+    // Get an index. This is a menu item so we know it has an index in its menu.
+    NSUInteger index = NSNotFound;
+    NSArray *siblings = [parent AXChildren];
+    if (siblings) {
+        index = [element indexAmongLikeElementsInArray:siblings];
+    }
+    NSString *title = [element AXTitle];
+    if (title && title.length > 0) {
+        [axPath appendFormat:@"/AXMenuItem[@AXTitle='%@']", title];
+    } else if (index != NSNotFound) {
+        [axPath appendFormat:@"/AXMenuItem[%lu]", index];
+    }
+    if (index != NSNotFound) {
+        [axPath appendFormat:@"/AXMenuItem[%lu]", index];
+    }
+    return axPath;
+}
+
+- (HIPoint)getMousePosition
+{
+    HIPoint position;
+    HICoordinateSpace space = kHICoordSpaceScreenPixel;
+    HIGetMousePosition(space, NULL, &position);
+    return position;
+}
+
+
+
+@end

--- a/AppiumForMac/Utility/KeystrokesAndKeyCodes.h
+++ b/AppiumForMac/Utility/KeystrokesAndKeyCodes.h
@@ -11,6 +11,14 @@
 
 // See Carbon/HIToolbox/Events.h for a list of virtual key codes
 
+// These constants are used in multiple places, and given names for readability.
+typedef NS_ENUM(UniChar, WebDriverKeyStroke) {
+    wdShiftKey = 0xE008,
+    wdControlKey = 0xE009,
+    wdAltKey = 0xE00A,
+    wdCommandKey = 0xE03D
+};
+
 @interface KeystrokesAndKeyCodes : NSObject
 
 + (CGKeyCode)keyCodeWithWebDriverKeystroke:(UniChar)keystroke isShifted:(BOOL *)isShiftedPtr;

--- a/AppiumForMac/Utility/KeystrokesAndKeyCodes.m
+++ b/AppiumForMac/Utility/KeystrokesAndKeyCodes.m
@@ -46,28 +46,28 @@
         case 0xE00C:
             returnedCode = kVK_Escape;         // 0x35
             break;
-        case 0xE03D:
+        case wdCommandKey:
             returnedCode = kVK_Command;        // 0x37
             break;
-        case 0xE008:
+        case wdShiftKey:
             returnedCode = kVK_Shift;         // 0x38
             break;
 //        case 0xFFFF:
 //            returnedCode = kVK_CapsLock;       // 0x39
 //            break;
-        case 0xE00A:
+        case wdAltKey:
             returnedCode = kVK_Option;         // 0x3A
             break;
-        case 0xE009:
+        case wdControlKey:
             returnedCode = kVK_Control;        // 0x3B
             break;
-//        case 0xE008:
+//        case wdShiftKey:
 //            returnedCode = kVK_RightShift;     // 0x3C      // WD does not define 'right...' keystrokes, so map to non-right
 //            break;
-//        case 0xE00A:
+//        case wdAltKey:
 //            returnedCode = kVK_RightOption;    // 0x3D      // WD does not define 'right...' keystrokes, so map to non-right
 //            break;
-//        case 0xE009:
+//        case wdControlKey:
 //            returnedCode = kVK_RightControl;   // 0x3E      // WD does not define 'right...' keystrokes, so map to non-right
 //            break;
 //        case 0xFFFF:

--- a/AppiumForMac/Utility/NotesWindow.xib
+++ b/AppiumForMac/Utility/NotesWindow.xib
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15G1217" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NotesWindowController">
+            <connections>
+                <outlet property="notesTextField" destination="sDC-U7-aLA" id="lzh-aE-PSM"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="AfM Notes" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" nonactivatingPanel="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="842" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="842" height="270"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField verticalHuggingPriority="750" id="sDC-U7-aLA">
+                        <rect key="frame" x="0.0" y="0.0" width="842" height="270"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <textFieldCell key="cell" selectable="YES" editable="YES" state="on" borderStyle="bezel" placeholderString="To add text, point to a UI element and press the function key." drawsBackground="YES" id="cQo-y0-elT">
+                            <font key="font" size="11" name="Monaco"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="483" y="380"/>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="iBY-En-iJB"/>
+    </objects>
+</document>

--- a/AppiumForMac/Utility/NotesWindowController.h
+++ b/AppiumForMac/Utility/NotesWindowController.h
@@ -1,0 +1,18 @@
+//
+//  NotesWindowController.h
+//  AppiumForMac
+//
+//  Created by Russell, Stuart on 2/11/17.
+//  Copyright © 2017 Appium. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+extern NSString * const kNotesWindowTextKey;
+extern NSString * const kShowNotesWindowOnLaunchKey;
+
+@interface NotesWindowController : NSWindowController <NSWindowDelegate>
+
+@property IBOutlet NSTextField *notesTextField;
+
+@end

--- a/AppiumForMac/Utility/NotesWindowController.m
+++ b/AppiumForMac/Utility/NotesWindowController.m
@@ -1,0 +1,74 @@
+//
+//  NotesWindowController.m
+//  AppiumForMac
+//
+//  Created by Russell, Stuart on 2/11/17.
+//  Copyright © 2017 Appium. All rights reserved.
+//
+
+#import "NotesWindowController.h"
+#import "AXPathUtility.h"
+
+NSString * const kNotesWindowTextKey = @"notesWindowText";
+NSString * const kShowNotesWindowOnLaunchKey = @"showNotesWindowOnLaunch";
+
+@interface NotesWindowController ()
+
+@end
+
+@implementation NotesWindowController
+
+- (instancetype)initWithWindowNibName:(NSString *)windowNibName
+{
+    self = [super initWithWindowNibName:windowNibName];
+    if (self) {
+    }
+    return self;
+}
+
+- (void)windowDidLoad {
+    [super windowDidLoad];
+    
+    NSString *savedString = [[NSUserDefaults standardUserDefaults] stringForKey:kNotesWindowTextKey];
+    if (savedString) {
+        [self.notesTextField setStringValue:savedString];
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSText* textEditor = [self.window fieldEditor:YES forObject:self.notesTextField];
+        NSRange range = {savedString.length, 0};
+        [textEditor setSelectedRange:range];
+    });
+    // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(newTextPosted:) name:kNewTextPostedNotification object:nil];
+}
+
+- (void)newTextPosted:(NSNotification *)note
+{
+    NSString *newString = note.object;
+    newString = [newString stringByAppendingString:@"\n\n"];
+    NSString *totalString = [[self.notesTextField stringValue] stringByAppendingString:newString];
+    [self.notesTextField setStringValue:totalString];
+    NSText* textEditor = [self.window fieldEditor:YES forObject:self.notesTextField];
+    NSRange range = {totalString.length, 0};
+    [textEditor setSelectedRange:range];
+    [textEditor scrollRangeToVisible:range];
+    
+    [[NSUserDefaults standardUserDefaults] setObject:totalString forKey:kNotesWindowTextKey];
+}
+
+- (void)windowWillClose:(NSNotification *)notification
+{
+    NSString *notesString = [self.notesTextField stringValue];
+    if (notesString == nil) {
+        notesString = @"";
+    }
+    [[NSUserDefaults standardUserDefaults] setObject:notesString forKey:kNotesWindowTextKey];
+}
+
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+@end

--- a/AppiumForMac/en.lproj/MainMenu.xib
+++ b/AppiumForMac/en.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15G1004" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15G1217" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
@@ -11,7 +11,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <menu title="AMainMenu" systemMenu="main" id="29">
             <items>
                 <menuItem title="AppiumForMac" id="56">
@@ -27,6 +27,12 @@
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
                             <menuItem title="Preferences…" keyEquivalent="," id="129"/>
+                            <menuItem title="Show Notes Window" keyEquivalent="n" id="lXx-uJ-ek4" userLabel="Show Notes Window">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="showNotesWindow:" target="-1" id="kcf-Dy-Nwu"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="143">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ You can see the new features in the calculator.py example script.
 AppiumForMac will generate OS X native keyboard and mouse events using Action syntax. Several examples are in /examples/calculator.py.
 
 #### click
-    ActionChains(driver).click(element).perform()
-    
-    ActionChains(driver).click().perform()
+ActionChains(driver).click(element).perform()
+
+ActionChains(driver).click().perform()
 
 #### move to
-    ActionChains(driver).move_to_element(element).perform()
+ActionChains(driver).move_to_element(element).perform()
 
 #### send keys
-    ActionChains(driver).send_keys('A string to type.').perform()
+ActionChains(driver).send_keys('A string to type.').perform()
 
 
 ### Absolute AXPath
@@ -62,7 +62,7 @@ A simple absolute AXPath:
     * does not use predicate strings containing braces [] or parens ()
     * uses single quotes, not double quotes for attribute strings
     * does not contain spaces, except within attribute string values (optional), and, surrounding boolean operators (required)
-    
+
 Notes:
 
     * The node "/AXApplication" without a predicate denotes the frontmost application.
@@ -73,20 +73,20 @@ Notes:
 Good examples:
 
     "/AXApplication[@AXTitle='Calculator']/AXWindow[0]/AXGroup[1]/AXButton[@AXDescription='clear']"
-    
+
     "/AXApplication[@AXTitle='Calculator']/AXMenuBarItems/AXMenuBarItem[@AXTitle='View']/AXMenu/AXMenuItem[@AXTitle='Scientific']"
-    
+
     "/AXApplication/AXMenuBarItems/AXMenuBarItem[@AXTitle='View']/AXMenu/AXMenuItem[@AXTitle='Basic' and @AXMenuItemMarkChar!='']"
-    
+
 
 Bad examples:
 
     "//AXButton[@AXDescription='clear']"
     (does not begin with /AXApplication, and contains //)
-    
+
     "/AXApplication[@AXTitle='Calculator']/AXWindow[0]/AXButton[@AXDescription='clear']"
     (not an absolute path: missing AXGroup)
-    
+
     "/AXApplication[@AXTitle="Calculator"]/AXWindow[0]"
     (a predicate string uses double quotes)
 
@@ -109,48 +109,63 @@ Bad examples:
     (predicate uses multiple kinds of boolean operators; use one or more 'and', or, use one or more 'or', but not both)
 
 
-### Implicit Timeouts
-AppumForMac supports standard implicit timeouts when finding an element. Pass a milliseconds value as a desired capability. The default is 0.0 seconds, that is, there will be only one attempt.
+### Automatic AXPath Recording
+Generating an AXPath for an element is easy: while AppiumForMac is running, just use the mouse to point to an element, then press the fn (function) key for a couple of seconds. AppiumForMac will build the AXPath of the element on screen, and copy it to the clipboard. You can then paste it into your script. 
 
-    For example, 'implicitTimeout':20000 will retry for 20 seconds before returning an error. 
+### Session Kill Switch
+If your script has gone off the rails, you need to stop it. But if a script is running, it can keep typing and clicking as you try to cancel it. Now, while a session is in progress, you can press the fn (function) key for a couple of seconds. AppiumForMac will cancel any open sessions. Your script will receive a "no such session" error.
 
-### Loop Delay
-During an implicit timeout to find an element, you can specify how long to wait between attempts. Pass a milliseconds value as a desired capability. The default is 1.0 seconds. The loop delay occurs _after_ each attempt, so if the element is found on the first attempt, there will be no delay. The total waiting time will not exceed implicitTimeout, regardless of the loopDelay value.
+### New Session Properties
+AppiumForMac sessions have several new properties. See below for a description of each. You can read and write the property values while your session is in progress, using cookies! Yes it is an odd way to use cookies, but it is the only way I could think of to support getting and setting generic session properties. There are a couple of existing commands in Selenium, but those are limited to a small set of properties, for example timeouts.
 
-    For example, 'loopDelay':1000 will wait 1 second between each attempt. 
+#### Getting and Setting Properties with a Cookie
+Each cookie is a dictionary with at least two keys: 'name' and 'value'. The Selenium commands are: get_cookies, get_cookie(), and addCookie().
 
-### Command Delay
-This provides a simple way to slow down a script if needed, e.g. for debugging. It specifies an arbitrary delay _before_ each command. Pass a milliseconds value as a desired capability. The default is 0.0 seconds so your script runs at full speed!
+1. To get all cookies, use driver.get_cookies(). This will return an array of cookie dictionaries. 
+1. To get one cookie, use driver.get_cookie('cookieName'). This will return the cookie with the name 'cookieName'.
+1. To set a cookie, use driver.add_cookie({'name': 'cookieName', 'value': 'cookieValue'}).
 
-    For example, 'commandDelay':2500 will wait 2.5 seconds before executing each command. 
+#### Implicit Timeouts
+AppiumForMac supports standard implicit timeouts when finding an element. The default is 0.0 seconds, that is, there will be only one attempt.
 
-### Mouse Move Speed
-For native mouse events, this determines how fast the mouse moves across the screen, in pixels per second. Several examples are in /examples/calculator.py.
+    For example, to set a 20.5 second timeout, use driver.add_cookie({'name': 'implicit_timeout', 'value': 20.5}). 
 
-    For example, 'mouseMoveSpeed':100 will move about 2x faster than 'mouseMoveSpeed':50.
-    
-    Be careful setting mouse speed too high, or your application may not detect the mouse-over for some elements.
+#### Loop Delay
+During an implicit timeout to find an element, you can specify how long to wait between attempts. The default is 1.0 seconds. The loop delay occurs _after_ each attempt, so if the element is found on the first attempt, there will be no delay. The total waiting time will not exceed implicit_timeout, regardless of the loop_delay value.
 
-### Session Diagnostics Directories
-AppiumForMac can create a directory for all diagnostics, named "AppiumDiagnostics". This will contain other items such as per-session diagnostic directories. The per-session directory stores items like screen shots. Pass a string file path in as a desiredCapability. If you do not pass any path, then there will be no diagnostic records, such as screen shots.
+    For example, to set a 1.7 second loop delay, use driver.add_cookie({'name': 'loop_delay', 'value': 1.7}). 
 
-    For example, "diagnosticsDirectoryLocation":"~/Documents/" will add a directory named AppiumDiagnostics to your Documents folder. 
+#### Command Delay
+This provides a simple way to slow down a script if needed, e.g. for debugging. It specifies an arbitrary delay _before_ each command. The default is 0.0 seconds so your script runs at full speed!
 
-### Screen Shots
-AppiumForMac can take a screen shot automatically whenever an element is not found before the implicit timeout. These can be used to analyze errors. The screen shots are stored in the per-session diagnostic directory. Pass in a non-zero number as a desiredCapability to enable the feature. If you pass in zero, or do not provide this desiredCapability, then there will be no screen shots.
+    For example, to wait 2.5 seconds before executing each command, use driver.add_cookie({'name': 'command_delay', 'value': 2.5}).
 
-    For example, "screenShotOnError":1 will enable automatic screen shots when find element fails.
-    
-    For example, "screenShotOnError":0 will disable screen shots.
+#### Mouse Speed
+For native mouse events, this determines how fast the mouse moves across the screen, approximately in points per second. The default is 100. A value of 50 will move the mouse about half as fast as 100.
 
+    For example, to set a very slow speed, use driver.add_cookie({'name': 'mouse_speed', 'value': 5}).
+
+Be careful setting mouse speed too high, or your application may not detect the mouse-over for some elements.
+
+#### Session Diagnostics Directories
+AppiumForMac can create a global directory for all diagnostics, named "AppiumDiagnostics". This will contain other items such as per-session diagnostic directories. The per-session directory stores items like screen shots. Set a string file path for the global directory. The default is not to use a diagnostics directory. If you do not set a path, or if you set an empty string for the path, then there will be no diagnostic records, such as screen shots.
+
+    For example, driver.add_cookie({'name': 'global_diagnostics_directory', 'value': '~/Desktop'}).
+
+#### Screen Shots for Errors
+AppiumForMac can take a screen shot automatically whenever an element is not found before the implicit timeout. These can be used to analyze errors. The screen shots are stored in the per-session diagnostic directory. The default is not to create screen shots for errors. If you do not set the global_diagnostics_directory cookie, then there will be no screen shots even if you enable them.
+
+    For example, to enable the feature, use driver.add_cookie({'name': 'screen_shot_on_error', 'value': True}).
+
+    For example, to enable the feature, use driver.add_cookie({'name': 'screen_shot_on_error', 'value': False}).
 
 
 ## New Features for Developers (as of November 2016)
 
 ### Greatly Simplified Code Pattern for Command Handlers.
-The code pattern for handler methods has changed substantially. A new method in AfMSessionController, executeWebDriverCommandWithPath:data:onMainThread:commandBlock:, performs the common tasks, such as looking up the session based on the path id, extracting json parameters, validating elements, and observing timeouts and delays. Each handler becomes a simple code block containing only the unique functional code for that handler.
+The code pattern for handler methods has changed substantially. A new method in AfMSessionController, executeWebDriverCommandWithPath:data:onMainThread:commandBlock:, performs the common tasks, such as looking up the session based on the path id, extracting json parameters, validating elements, and observing timeouts and delays. Your handler becomes a simple code block containing only the unique functional code for that handler.
 
-There is no more need to update the giant httpResponseForMethod:URI: method. The name of each handler is dynamically constructed from the http request. All you have to do is name your handler correctly and it will get executed.
+The name of each handler is dynamically constructed from the http request. All you have to do is name your handler correctly and it will get executed.
 
 #### Creating a new command handler
 
@@ -172,16 +187,16 @@ There is no more need to update the giant httpResponseForMethod:URI: method. The
     * session: The AfMSessionController instance created when your script created a new web driver. This provides access to the machine and other applications.
     * commandParams: A dictionary containing http request parameters. It includes elements referenced from the URL path, and all POST json objects. The "elementObject" dictionary key retrieves a validated element.
     * status: A pointer to an int to write back a status code to your caller. This is not a substitute for your handler return value.
-    
-1. Your code block should return an object created with [AppiumMacHTTPJSONResponse responseWithJson:status:session:] or [AppiumMacHTTPJSONResponse responseWithJsonError:session:].
+
+1. Your code block should return an object and a status value created with either [AppiumMacHTTPJSONResponse responseWithJson:status:session:] or [AppiumMacHTTPJSONResponse responseWithJsonError:session:].
 1. If your code block returns responseWithJsonError:kAfMStatusCodeNoSuchElement, then the block (not the entire handler method) will be automatically called again, within the constraints of implicitTimeout, and loopDelay.
 1. However, if your block returns nil, then a kAfMStatusCodeNoSuchElement error is _immediately_ returned to the scripter, even if implicitTimeout has not yet been reached.
-1. If you expect thrown exceptions, add them to your own code block. Execution exceptions which you do not catch are logged but not re-thrown.
+1. If you want to process thrown exceptions, put a try block in your own code block. Uncaught execution exceptions are logged but not re-thrown.
 1. AppiumForMac automatically returns common errors to the scripter so you don't need to worry about them:
 
-    * There is no session with the sessionId specified in the request path.
-    * The specified element is invalid.
-    * Your handler returned kAfMStatusCodeNoSuchElement, but the implicitTimeout period was exceeded.
-    * Your handler doesn't exist (or you named it incorrectly).
-    * Your handler returned a nil value.
+    * kAfMStatusCodeNoSuchDriver - there is no session with the sessionId specified in the request path
+    * kAfMStatusCodeUnknownCommand - your handler method may have been named improperly
+    * kAfMStatusCodeStaleElementReference - a previously located element no longer exists
+    * kAfMStatusCodeNoSuchWindow - the current window no longer exists
+    * kAfMStatusCodeSessionNotCreatedException - the maximum number of sessions are open
 


### PR DESCRIPTION
This is only the app. New example files not included.

AfMElementLocator.m
(findUsingBaseUIElement:statusCode:)
- requireAbsoluteAXPath = YES for the time being.

AfMHandlers.h
AfMHandlers.m
- Added get_cookie: and post_cookie:data: as a sneaky way to get and set runtime preferences while a session is in progress.
- Removed post_execute which applies only to web pages.
(post_url:data:)
- Moved the code into the session controller postURL because it interacts with the machine.

AfMStatusCodes
- Added kAfMStatusCodeInvalidArgument.

NotesWindowController.h
NotesWindowController.m
NotesWindow.xib
- Added editable text utility window

KeystrokesAndKeyCodes.h
KeystrokesAndKeyCodes.m
- Added WebDriverKeyStroke enum to give names to modifier constants.

AppiumForMacAppDelegate.h
AppiumForMacAppDelegate.m
MainMenu.xib
- Added fn key monitor to detect when the fn key is pressed, and post a notification when held down more than 1 second.
- Added IBAction to show the notes window if it was closed.

AXPathUtility.h
AXPathUtility.m
- Added to build axPath for the point under the mouse. This is triggered when the fn key is held down.

AfMSessionController.h
AfMSessionController.m
- Added string constants for getting and setting native session cookies.
- Added diagnosticsDirectory.

(getAllCookies getCookieWithName: setCookie:)
- Added to allow real-time control of session capabilities and behaviors.

- Replaced instance variables with cookies, for capabilities and behaviors.

(allWindows)
- just return the windows. Don't include the current application.

(setDesiredCapabilities:)
- Use an array of cookies from the script instead of a dictionary.

(executeWebDriverCommandWithPath:)
- Return kAfMStatusCodeInvalidArgument if jsonParams is missing or invalid class.

(currentApplicationName setCurrentApplicationName)
- Uncommented.

(postURL)
- Added to launch an app (this was previously in AfMHandlers).

(fnKeyTrigger)
- Feature: when the user holds down the fn key, cancel the session. This allows cancelling when the script is running on the same machine.
(setGlobalDiagnosticsDirectoryCookie:)
- Added.

README.md
- Updated with nifty new stuff.