### PR TITLE
Adds the ability to run bash script through appium-for-mac

### DIFF
--- a/AppiumForMac/Server/Controller/AfMSessionController.h
+++ b/AppiumForMac/Server/Controller/AfMSessionController.h
@@ -143,6 +143,7 @@ extern NSString * const kCookieDiagnosticsDirectory;
 - (BOOL)isElementDisplayed:(id)element;
 -(BOOL) clickElement:(id)element;
 -(void) closeWindow;
+- (NSString *)runCommand:(NSString *)commandToRun;
 -(NSDictionary*) pageSource;
 -(NSInteger) pidForProcessName:(NSString*)processName;
 -(SystemEventsProcess*) processForName:(NSString*)processName;

--- a/AppiumForMac/Server/Controller/AfMSessionController.h
+++ b/AppiumForMac/Server/Controller/AfMSessionController.h
@@ -143,7 +143,7 @@ extern NSString * const kCookieDiagnosticsDirectory;
 - (BOOL)isElementDisplayed:(id)element;
 -(BOOL) clickElement:(id)element;
 -(void) closeWindow;
-- (NSString *)runCommand:(NSString *)commandToRun;
+- (NSString *)executeShellScript:(NSString *)script;
 -(NSDictionary*) pageSource;
 -(NSInteger) pidForProcessName:(NSString*)processName;
 -(SystemEventsProcess*) processForName:(NSString*)processName;

--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -574,6 +574,31 @@ NSInteger const kPredicateRightOperand = 1;
     [self.currentWindow performAction:@"AXCancel"];
 }
 
+- (NSString *)runCommand:(NSString *)commandToRun
+{
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/bin/sh"];
+    
+    NSArray *arguments = [NSArray arrayWithObjects:
+                          @"-c" ,
+                          [NSString stringWithFormat:@"%@", commandToRun],
+                          nil];
+    NSLog(@"run command:%@", commandToRun);
+    [task setArguments:arguments];
+    
+    NSPipe *pipe = [NSPipe pipe];
+    [task setStandardOutput:pipe];
+    
+    NSFileHandle *file = [pipe fileHandleForReading];
+    
+    [task launch];
+    
+    NSData *data = [file readDataToEndOfFile];
+    
+    NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    return output;
+}
+
 -(NSString*) currentApplicationName
 {
 	return self._currentApplicationName;

--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -574,16 +574,17 @@ NSInteger const kPredicateRightOperand = 1;
     [self.currentWindow performAction:@"AXCancel"];
 }
 
-- (NSString *)runCommand:(NSString *)commandToRun
+- (NSString *)executeShellScript:(NSString *)script
 {
     NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath:@"/bin/sh"];
+    [task setLaunchPath:@"/bin/bash"];
     
     NSArray *arguments = [NSArray arrayWithObjects:
                           @"-c" ,
-                          [NSString stringWithFormat:@"%@", commandToRun],
+                          [NSString stringWithFormat:@"%@", script],
                           nil];
-    NSLog(@"run command:%@", commandToRun);
+    
+    NSLog(@"running bash script:'%@'", script);
     [task setArguments:arguments];
     
     NSPipe *pipe = [NSPipe pipe];

--- a/AppiumForMac/Server/Handlers/AfMHandlers.h
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.h
@@ -54,7 +54,10 @@
 // POST /session/:sessionId/forward
 // POST /session/:sessionId/back
 // POST /session/:sessionId/refresh
+
 // POST /session/:sessionId/execute
+- (AppiumMacHTTPJSONResponse *)post_execute:(NSString*)path data:(NSData*)postData;
+
 // POST /session/:sessionId/execute_async
 
 // GET /session/:sessionId/screenshot

--- a/AppiumForMac/Server/Handlers/AfMHandlers.m
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.m
@@ -240,6 +240,19 @@
 // POST /session/:sessionId/execute
 // Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame. The executed script is assumed to be synchronous and the result of evaluating the script is returned to the client.
 
+- (AppiumMacHTTPJSONResponse *)post_execute:(NSString*)path data:(NSData*)postData
+{
+    return [self executeWebDriverCommandWithPath:path data:postData onMainThread:YES commandBlock:^(AfMSessionController *session, NSDictionary *commandParams, int *statusCode)
+            {
+                // The bash command to run
+                NSString *command = (NSString*)[commandParams objectForKey:@"script"];
+                
+                NSString *commandResult = [session runCommand:command];
+                
+                return [AppiumMacHTTPJSONResponse responseWithJson:commandResult status:kAfMStatusCodeSuccess session:session.sessionId];
+            }];
+}
+
 // POST /session/:sessionId/execute_async
 // Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame. The executed script is assumed to be asynchronous and must signal that is done by invoking the provided callback, which is always provided as the final argument to the function. 
 

--- a/AppiumForMac/Server/Handlers/AfMHandlers.m
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.m
@@ -243,14 +243,12 @@
 - (AppiumMacHTTPJSONResponse *)post_execute:(NSString*)path data:(NSData*)postData
 {
     return [self executeWebDriverCommandWithPath:path data:postData onMainThread:YES commandBlock:^(AfMSessionController *session, NSDictionary *commandParams, int *statusCode)
-            {
-                // The bash command to run
-                NSString *command = (NSString*)[commandParams objectForKey:@"script"];
-                
-                NSString *commandResult = [session runCommand:command];
-                
-                return [AppiumMacHTTPJSONResponse responseWithJson:commandResult status:kAfMStatusCodeSuccess session:session.sessionId];
-            }];
+    {
+        // The bash script to run
+        NSString *script = (NSString*)[commandParams objectForKey:@"script"];
+        NSString *scriptResult = [session executeShellScript: script];
+        return [AppiumMacHTTPJSONResponse responseWithJson:scriptResult status:kAfMStatusCodeSuccess session:session.sessionId];
+    }];
 }
 
 // POST /session/:sessionId/execute_async


### PR DESCRIPTION
we can now run bash script on the target machine running the appium-for-mac using the selenium driver.execute_script("mybashcommand")