### PR TITLE
Workaround for the case TISCopyCurrentKeyboardLayoutInputSource() returns NULL

### DIFF
--- a/AppiumForMac/Utility/KeystrokesAndKeyCodes.m
+++ b/AppiumForMac/Utility/KeystrokesAndKeyCodes.m
@@ -348,7 +348,15 @@ CFStringRef createStringForKeyCode(CGKeyCode keyCode)
     TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
     CFDataRef layoutData =
     TISGetInputSourceProperty(currentKeyboard,
+                              kTISPropertyUnicodeKeyLayoutData);  // This may return NULL.
+
+    if (!layoutData) {
+        currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
+        layoutData =
+        TISGetInputSourceProperty(currentKeyboard,
                               kTISPropertyUnicodeKeyLayoutData);
+    }
+
     const UCKeyboardLayout *keyboardLayout =
     (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
     


### PR DESCRIPTION
TISGetInputSourceProperty returns NULL if the specified property is missing or invalid for the specified input source. Such as Japanese keyboard layout causes this problem.

Appium for mac crashes when the function returns NULL because of NULL pointer access.

I found a workaround for the problem (https://github.com/Kentzo/ShortcutRecorder/issues/56#issuecomment-190102586) and add it to appium. I feel it seems to work fine.

![xcode_capture](https://i.imgur.com/bLZWjhi.png)