### PR TITLE
REDIRECTING AFM LOGS INTO EXTERNAL FILE. ADDED LOGS FOR REQUEST AND R…

### DIFF
--- a/AppiumForMac/Library/CocoaHTTPServer/Vendor/CocoaLumberjack/DDFileLogger.h
+++ b/AppiumForMac/Library/CocoaHTTPServer/Vendor/CocoaLumberjack/DDFileLogger.h
@@ -25,7 +25,7 @@
 // 
 // You should carefully consider the proper configuration values for your application.
 
-#define DEFAULT_LOG_MAX_FILE_SIZE     (1024 * 1024)   //  1 MB
+#define DEFAULT_LOG_MAX_FILE_SIZE     (1024 * 1024*1024)   //  1024 MB
 #define DEFAULT_LOG_ROLLING_FREQUENCY (60 * 60 * 24)  // 24 Hours
 #define DEFAULT_LOG_MAX_NUM_LOG_FILES (5)             //  5 Files
 

--- a/AppiumForMac/Library/CocoaHTTPServer/Vendor/CocoaLumberjack/DDFileLogger.m
+++ b/AppiumForMac/Library/CocoaHTTPServer/Vendor/CocoaLumberjack/DDFileLogger.m
@@ -416,7 +416,7 @@
 	NSString *logsDirectory = [self logsDirectory];
 	do
 	{
-		NSString *fileName = [NSString stringWithFormat:@"log-%@.txt", [self generateShortUUID]];
+		NSString *fileName = [NSString stringWithFormat:@"AFMlog.txt"];
 		
 		NSString *filePath = [logsDirectory stringByAppendingPathComponent:fileName];
 		

--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -15,6 +15,9 @@
 #import "AppiumForMacAppDelegate.h"
 #import "KeystrokesAndKeyCodes.h"
 #import "Utility.h"
+#import "DDLog.h"
+
+static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 
 NSString * const kCookieLoopDelay = @"loop_delay";
 NSString * const kCookieImplicitTimeout = @"implicit_timeout";
@@ -161,112 +164,112 @@ NSInteger const kPredicateRightOperand = 1;
 - (NSTimeInterval)loopDelay
 {
     NSNumber *value = [self getCookieWithName:kCookieLoopDelay][@"value"];
-//    NSLog(@"loopDelay: %f", [value floatValue]);
+    DDLogCInfo(@"loopDelay: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (NSTimeInterval)commandDelay
 {
     NSNumber *value = [self getCookieWithName:kCookieCommandDelay][@"value"];
-//    NSLog(@"commandDelay: %f", [value floatValue]);
+    DDLogCInfo(@"commandDelay: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (NSTimeInterval)implicitTimeout
 {
     NSNumber *value = [self getCookieWithName:kCookieImplicitTimeout][@"value"];
-//    NSLog(@"implicitTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"implicitTimeout: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (NSTimeInterval)pageLoadTimeout
 {
     NSNumber *value = [self getCookieWithName:kCookiePageLoadTimeout][@"value"];
-//    NSLog(@"pageLoadTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"pageLoadTimeout: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (NSTimeInterval)scriptTimeout
 {
     NSNumber *value = [self getCookieWithName:kCookieScriptTimeout][@"value"];
-//    NSLog(@"scriptTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"scriptTimeout: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (float)mouseMoveSpeed
 {
     NSNumber *value = [self getCookieWithName:kCookieMouseSpeed][@"value"];
-//    NSLog(@"mouseMoveSpeed: %f", [value floatValue]);
+    DDLogCInfo(@"mouseMoveSpeed: %f", [value floatValue]);
     return [value floatValue];
 }
 
 - (BOOL)shouldTakeScreenShot
 {
     NSNumber *value = [self getCookieWithName:kCookieScreenShotOnError][@"value"];
-//    NSLog(@"shouldTakeScreenShot: %@", [value boolValue] ? @"YES":@"NO");
+    DDLogCInfo(@"shouldTakeScreenShot: %@", [value boolValue] ? @"YES":@"NO");
     return [value boolValue];
 }
 
 - (NSString *)globalDiagnosticsDirectory
 {
     NSString *value = [self getCookieWithName:kCookieGlobalDiagnosticsDirectory][@"value"];
-//    NSLog(@"globalDiagnosticsDirectory: %@", value);
+    DDLogCInfo(@"globalDiagnosticsDirectory: %@", value);
     return value;
 }
 
 - (NSString *)diagnosticsDirectory
 {
     NSString *value = [self getCookieWithName:kCookieDiagnosticsDirectory][@"value"];
-//    NSLog(@"diagnosticsDirectory: %@", value);
+    DDLogCInfo(@"diagnosticsDirectory: %@", value);
     return value;
 }
 
 - (void)setLoopDelay:(NSTimeInterval)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setLoopDelay: %f", [value floatValue]);
+    DDLogCInfo(@"setLoopDelay: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookieLoopDelay, @"value": value}];
 }
 
 - (void)setCommandDelay:(NSTimeInterval)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setCommandDelay: %f", [value floatValue]);
+    DDLogCInfo(@"setCommandDelay: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookieCommandDelay, @"value": value}];
 }
 
 - (void)setImplicitTimeout:(NSTimeInterval)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setImplicitTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"setImplicitTimeout: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookieImplicitTimeout, @"value": value}];
 }
 
 - (void)setPageLoadTimeout:(NSTimeInterval)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setPageLoadTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"setPageLoadTimeout: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookiePageLoadTimeout, @"value": value}];
 }
 
 - (void)setScriptTimeout:(NSTimeInterval)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setScriptTimeout: %f", [value floatValue]);
+    DDLogCInfo(@"setScriptTimeout: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookieScriptTimeout, @"value": value}];
 }
 
 - (void)setMouseMoveSpeed:(float)interval
 {
     NSNumber *value = [NSNumber numberWithFloat:interval];
-//    NSLog(@"setMouseMoveSpeed: %f", [value floatValue]);
+    DDLogCInfo(@"setMouseMoveSpeed: %f", [value floatValue]);
     [self setCookie:@{@"name": kCookieMouseSpeed, @"value": value}];
 }
 
 - (void)setShouldTakeScreenShot:(BOOL)yesNo
 {
     NSNumber *value = [NSNumber numberWithBool:yesNo];
-//    NSLog(@"setShouldTakeScreenShot: %@", [value boolValue] ? @"YES":@"NO");
+    DDLogCInfo(@"setShouldTakeScreenShot: %@", [value boolValue] ? @"YES":@"NO");
     [self setCookie:@{@"name": kCookieScreenShotOnError, @"value": value}];
 }
 
@@ -278,7 +281,7 @@ NSInteger const kPredicateRightOperand = 1;
 
 - (void)setDiagnosticsDirectory:(NSString *)value
 {
-//    NSLog(@"setDiagnosticsDirectory: %@", value);
+    DDLogCInfo(@"setDiagnosticsDirectory: %@", value);
     [self setCookie:@{@"name": kCookieDiagnosticsDirectory, @"value": value}];
 }
 
@@ -468,7 +471,7 @@ NSInteger const kPredicateRightOperand = 1;
                 handlerReturnValue = commandBlock(self, commandParams, &statusCode);
             }
             @catch (NSException *e) {
-                NSLog(@"Exception in dispatch_sync(dispatch_get_main_queue()): %@", e);
+                DDLogCInfo(@"Exception in dispatch_sync(dispatch_get_main_queue()): %@", e);
             }
         };
         
@@ -492,14 +495,14 @@ NSInteger const kPredicateRightOperand = 1;
             } else if ([timeoutDate timeIntervalSinceNow] > 0) {
                 [NSThread sleepForTimeInterval:[timeoutDate timeIntervalSinceNow]];
             }
-            //NSLog(@"Session %@ waiting for commandParams: %@ time remaining: %f", sessionId, commandParams, [timeoutDate timeIntervalSinceNow]);
+            DDLogCInfo(@"Session %@ waiting for commandParams: %@ time remaining: %f", sessionId, commandParams, [timeoutDate timeIntervalSinceNow]);
             continue;
         } else {
             return handlerReturnValue;
         }
     }
     if (self.isCanceled) {
-        NSLog(@"executeWebDriverCommandWithPath:: session isCanceled after waiting: %@", self.sessionId);
+        DDLogCInfo(@"executeWebDriverCommandWithPath:: session isCanceled after waiting: %@", self.sessionId);
         return [AppiumMacHTTPJSONResponse responseWithJsonError:kAfMStatusCodeNoSuchDriver session:self.sessionId];
     }
     if ([handlerReturnValue afmStatusCode] == kAfMStatusCodeNoSuchElement

--- a/AppiumForMac/Server/Responses/AppiumMacHTTPJSONResponse.m
+++ b/AppiumForMac/Server/Responses/AppiumMacHTTPJSONResponse.m
@@ -10,7 +10,8 @@
 #import "AppiumMacHTTP303JSONResponse.h"
 #import "AfMStatusCodes.h"
 #import "HTTPLogging.h"
-
+#import "DDLog.h"
+static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 // Commented out unused variable to avoid compiler warning.
 //static const int httpLogLevel = HTTP_LOG_LEVEL_WARN;
 
@@ -18,6 +19,7 @@
 
 +(AppiumMacHTTPJSONResponse *) responseWithJson:(id)json status:(int)status session:(NSString*)session
 {
+    DDLogCInfo(@"response:%@", json);
     return [self responseWithJson:json status:status session:session statusCode:200];
 }
 
@@ -37,7 +39,7 @@
                                                          error:&error];
     if (!jsonData)
     {
-        NSLog(@"Got an error: %@", error);
+        DDLogCInfo(@"Got an error: %@", error);
         jsonData = [NSJSONSerialization dataWithJSONObject:
                     [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:-1], @"status", session, @"session", [NSString stringWithFormat:@"%@", error], @"value" , nil]
                                                    options:NSJSONWritingPrettyPrinted
@@ -45,6 +47,7 @@
     }
     switch (statusCode)
     {
+        DDLogCInfo(@"response:%@", jsonData);
         case 303:
             return [[AppiumMacHTTP303JSONResponse alloc] initWithData:jsonData];
         default:
@@ -55,6 +58,9 @@
 + (AppiumMacHTTPJSONResponse *)responseWithJsonError:(int)statusCode session:(NSString*)sessionId
 {
     NSDictionary *errorJson = [NSDictionary dictionaryWithObjectsAndKeys:kAfMStatusCodeMessages[statusCode],@"message" , nil];
+    DDLogCInfo(@"response:%@", errorJson);
+    DDLogCInfo(@"status:%d", statusCode);
+    DDLogCInfo(@"session:%@", sessionId);
     return [self responseWithJson:errorJson status:statusCode session:sessionId];
 }
 

--- a/AppiumForMac/Utility/AXPathUtility.m
+++ b/AppiumForMac/Utility/AXPathUtility.m
@@ -11,9 +11,11 @@
 
 #import "AXPathUtility.h"
 #import "AppiumForMacAppDelegate.h"
+#import "DDLog.h"
 
 NSUInteger const kMaximumTitleLength = 256;
 NSString * const kNewTextPostedNotification = @"NewTextPosted";
+static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 
 @implementation AXPathUtility
 
@@ -36,7 +38,7 @@ NSString * const kNewTextPostedNotification = @"NewTextPosted";
     HIPoint currentMousePosition = [self getMousePosition];
     NSSize offset;
     NSString *axPath = [self axPathAtMousePosition:currentMousePosition offsetPercent:&offset];
-    NSLog(@"axPath:\n%@", axPath);
+    DDLogCInfo(@"axPath:\n%@", axPath);
     if (axPath && axPath.length) {
         // Add surrounding double quotes to the path string.
         NSString *quotedAXPath = [NSString stringWithFormat:@"\"%@\"", axPath];
@@ -62,7 +64,7 @@ NSString * const kNewTextPostedNotification = @"NewTextPosted";
     PFUIElement *hitElement = [PFUIElement elementAtPoint:mousePosition withDelegate:nil error:&error];
     if (!hitElement) {
         // No element under the mouse? How odd.
-        NSLog(@"axPathAtMousePosition ERROR no hitElement at mousePosition: %@ NSError:%@", NSStringFromPoint(mousePosition), error);
+        DDLogCInfo(@"axPathAtMousePosition ERROR no hitElement at mousePosition: %@ NSError:%@", NSStringFromPoint(mousePosition), error);
         return nil;
     }
     
@@ -121,7 +123,7 @@ NSString * const kNewTextPostedNotification = @"NewTextPosted";
         if (role) {
             [axPath appendString:role];
         } else {
-            NSLog(@"axPathAtMousePosition ERROR role is nil for element:%@ partialAXPath:%@", hitElement, axPath);
+            DDLogCInfo(@"axPathAtMousePosition ERROR role is nil for element:%@ partialAXPath:%@", hitElement, axPath);
         }
         
         // Add a predicate to the role.
@@ -176,7 +178,7 @@ NSString * const kNewTextPostedNotification = @"NewTextPosted";
 // (indexes can vary per application and per application state e.g. running or not, active/non-active/hidden)
 - (NSString *)axPathForDockAXMenuItem:(PFUIElement *)element
 {
-    NSLog(@"axPathForDockAXMenuItem element:%@", element); 
+    DDLogCInfo(@"axPathForDockAXMenuItem element:%@", element);
     
     if (!element || ![element isRole:@"AXMenuItem"]) {
         return nil;
@@ -198,8 +200,8 @@ NSString * const kNewTextPostedNotification = @"NewTextPosted";
         dockApp = (PFApplicationUIElement *)[[grandParent AXParent] AXParent];
     }
     
-    NSLog(@"dockApp AXChildren:\n%@", [dockApp AXChildren]);
-    NSLog(@"dockApp AXFocusedUIElement:\n%@", [dockApp AXFocusedUIElement]);
+    DDLogCInfo(@"dockApp AXChildren:\n%@", [dockApp AXChildren]);
+    DDLogCInfo(@"dockApp AXFocusedUIElement:\n%@", [dockApp AXFocusedUIElement]);
     // Big assumption: the Dock will always be named "Dock".
     [axPath appendString:@"/AXApplication[@AXTitle='Dock']"];
     


### PR DESCRIPTION
I have done the following changes related to logs.
1. Added DDFileLogger to stream the AFM Logs into external default file location(~/Documents/LogFile/AFMlog.txt)
2. Added Info Logs for every Rest Request End Point and HttpResponse for easy debugging.
3. Added AXLocator into Logs while inspecting with Fn Key. This can speed up the scripting while going through the flow.

Note:1. I could able to build and run the AFM Application successfully with out any issues.
         2. I could able to run our tests with out any issues successfully. No regression issues identified with these new changes.
         3. The log file is getting created successfully while launching the AFM.
         4. Attached Sample Local 
[AFMlog.txt](https://github.com/appium/appium-for-mac/files/3219749/AFMlog.txt)
Log file

Thanks
Santhosh.
