### PR TITLE
fix: Be able to build without sign for dev

### DIFF
--- a/AppiumForMac.xcodeproj/project.pbxproj
+++ b/AppiumForMac.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 3610347C17A4990E00DB79AA;
@@ -832,6 +833,7 @@
 		361034B717A4990F00DB79AA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/AppiumForMac/Library/CocoaHTTPServer/Core/WebSocket.m
+++ b/AppiumForMac/Library/CocoaHTTPServer/Core/WebSocket.m
@@ -134,7 +134,7 @@ static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame)
 	if (!upgradeHeaderValue || !connectionHeaderValue) {
 		isWebSocket = NO;
 	}
-	else if (![upgradeHeaderValue caseInsensitiveCompare:@"WebSocket"] == NSOrderedSame) {
+	else if ((![upgradeHeaderValue caseInsensitiveCompare:@"WebSocket"]) == NSOrderedSame) {
 		isWebSocket = NO;
 	}
 	else if ([connectionHeaderValue rangeOfString:@"Upgrade" options:NSCaseInsensitiveSearch].location == NSNotFound) {


### PR DESCRIPTION
Current this project can build only on Xcode 10 environment.
After switching to Xcode 11, the below error occurred without any changes.

```
CodeSign /Users/kazu/GitHub/appium-for-mac/build/Release/AppiumForMac.app/Contents/Frameworks/PFAssistive.framework/Versions/A (in target 'AppiumForMac' from project 'AppiumForMac')
    cd /Users/kazu/GitHub/appium-for-mac
    export CODESIGN_ALLOCATE=/Applications/Xcode_11.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate

Signing Identity:     "-"

    /usr/bin/codesign --force --sign - --timestamp=none --preserve-metadata=identifier,entitlements,flags /Users/kazu/GitHub/appium-for-mac/build/Release/AppiumForMac.app/Contents/Frameworks/PFAssistive.framework/Versions/A
/Users/kazu/GitHub/appium-for-mac/build/Release/AppiumForMac.app/Contents/Frameworks/PFAssistive.framework/Versions/A: bundle format unrecognized, invalid, or unsuitable
Command CodeSign failed with a nonzero exit code

** BUILD FAILED **


The following build commands failed:
	CodeSign /Users/kazu/GitHub/appium-for-mac/build/Release/AppiumForMac.app/Contents/Frameworks/PFAssistive.framework/Versions/A
(1 failure)
```

With this change, we can build without a sign by `xcodebuild -configuration Debug`

(I fixed a warning in AppiumForMac/Library/CocoaHTTPServer/Core/WebSocket.m by Xcode 11, too)