### PR TITLE
fix: Ensure JSON responses with the value key set to null is serialized correctly.

### DIFF
--- a/AppiumForMac/Server/Responses/AppiumMacHTTPJSONResponse.m
+++ b/AppiumForMac/Server/Responses/AppiumMacHTTPJSONResponse.m
@@ -29,7 +29,7 @@
     {
         [responseJson setValue:session forKey:@"sessionId"];
     }
-    [responseJson setValue:json forKey:@"value"];
+    [responseJson setValue:(json ?: [NSNull null]) forKey:@"value"];
     
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:responseJson


### PR DESCRIPTION
When using the browser.keys() API via webdriver.io, WDIO expects a value key
to be present in the response. Currently, this JSON response is not serialized
correctly by AppiumForMac.

This commit remedies that by using an NSNull value in place of a bare nil.
This causes the response to be correctly serialized as intended.

Note: this is not exclusive to AppiumForMac. For example, WinAppDriver
has a very similar bug:
https://github.com/microsoft/WinAppDriver/issues/740