### PR TITLE
fix: create a diagnostics directory for a proper session

### DIFF
--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -1838,9 +1838,9 @@ const NSTimeInterval kModifierPause = 0.05;
             dateString = [dateString stringByReplacingOccurrencesOfString:@":" withString:@"_"];
             fileName = [NSString stringWithFormat:@"%@__%@", fileName, dateString];
         }
-        
+
         NSString *filePath = [NSString stringWithFormat:@"%@/%@.png", self.diagnosticsDirectory, fileName];
-        
+
         NSLog(@"Creating screenshot: %@", filePath);
         system([[NSString stringWithFormat:@"/usr/sbin/screencapture -mx %@", filePath] cStringUsingEncoding:NSASCIIStringEncoding]);
     }
@@ -1893,7 +1893,7 @@ const NSTimeInterval kModifierPause = 0.05;
     NSString *sessionPath = [directoryPath stringByAppendingString:sessionDirectoryName];
     
     NSError *error = nil;
-    [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:&error];
+    [[NSFileManager defaultManager] createDirectoryAtPath:sessionPath withIntermediateDirectories:YES attributes:nil error:&error];
     if (error) {
         NSLog(@"createDirectoryAtPath:%@ error:%@", sessionPath, error);
     } else {


### PR DESCRIPTION
`self.diagnosticsDirectory` should be `sessionPath` in L1900, but L1896 creates directory until the parent directory.
So, saving a screenshot like below fails since `session-qKXraEAn` part haven't been created.
`directoryPath` is `/Users/kazuaki/Desktop/AppiumDiagnostics/`, `sessionPath` should be `/Users/kazuaki/Desktop/AppiumDiagnostics/session-qKXraEAn/`.

```
[Appium4Mac] [STDERR] 2020-07-07 01:28:20.843 AppiumForMac[10195:4912126] Creating screenshot: /Users/kazuaki/Desktop/AppiumDiagnostics/session-qKXraEAn/element__2020-07-06_16_28_20_+0000.png
```

This will fix https://github.com/appium/appium-for-mac#screen-shots-for-errors behaviour
(Current implementation did not create `session-qKXraEAn` part so this feature always fails since no directory.)