### PR TITLE
ci: update release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
     - name: Archive the AppiumForMac.app
       run: |
-        mv $GITHUB_WORKSPACE/Build/Products/Debug $GITHUB_WORKSPACE
-        zip -r Debug_AppiumForMac.zip Debug/AppiumForMac.app
+        mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
+        zip -r Debug_AppiumForMac.zip AppiumForMac.app
     - name: Upload the AppiumForMac.app
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run xcodebuild
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
-    - name: Archive the AppiumForMac.app
+    - name: Archive the AppiumForMac.app without extended metadata
       run: |
         mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
         xattr -cr AppiumForMac.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
     - name: Archive the AppiumForMac.app
       run: |
-        mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
-        zip -r Debug_AppiumForMac.zip AppiumForMac.app
+        mv $GITHUB_WORKSPACE/Build/Products/Debug $GITHUB_WORKSPACE
+        zip -r Debug_AppiumForMac.zip Debug/AppiumForMac.app
     - name: Upload the AppiumForMac.app
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Archive the AppiumForMac.app
       run: |
         mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
+        xattr -cr AppiumForMac.app
         zip -r Debug_AppiumForMac.zip AppiumForMac.app
     - name: Upload the AppiumForMac.app
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,13 @@ jobs:
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
     - name: Archive the AppiumForMac.app
       run: |
-        mv $GITHUB_WORKSPACE/Build/Products/Debug $GITHUB_WORKSPACE
-        zip -r Debug_AppiumForMac.zip Debug/AppiumForMac.app
+        mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
+        zip -r Debug_AppiumForMac.zip AppiumForMac.app
+    - name: Upload the AppiumForMac.app
+      uses: actions/upload-artifact@v2
+      with:
+        name: Debug_AppiumForMac
+        path: Debug_AppiumForMac.zip
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
         draft: false
-        prerelease: true
+        prerelease: false
     - name: Upload Debug_AppiumForMac
       id: upload-release-asset
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-        body: |
-          Changes in this Release:
-          - Please update items included in this release
-        draft: true
+        draft: false
         prerelease: true
     - name: Upload Debug_AppiumForMac
       id: upload-release-asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run xcodebuild
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
-    - name: Archive the AppiumForMac.app
+    - name: Archive the AppiumForMac.app without extended metadata
       run: |
         mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
         xattr -cr AppiumForMac.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Archive the AppiumForMac.app
       run: |
         mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
+        xattr -cr AppiumForMac.app
         zip -r Debug_AppiumForMac.zip AppiumForMac.app
     - name: Upload the AppiumForMac.app
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
       run: xcodebuild -scheme AppiumForMac -configuration Debug -derivedDataPath $GITHUB_WORKSPACE build
     - name: Archive the AppiumForMac.app
       run: |
-        mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
-        zip -r Debug_AppiumForMac.zip AppiumForMac.app
+        mv $GITHUB_WORKSPACE/Build/Products/Debug $GITHUB_WORKSPACE
+        zip -r Debug_AppiumForMac.zip Debug/AppiumForMac.app
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -25,14 +25,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Created by Actions automatically
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: ${{ github.ref }}
         body: |
-          Changes in this Release
-          - Release note
+          Changes in this Release:
+          - Please update items included in this release
         draft: true
         prerelease: false
     - name: Upload Debug_AppiumForMac
-      id: upload-release-asset 
+      id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,6 @@ jobs:
         mv $GITHUB_WORKSPACE/Build/Products/Debug/AppiumForMac.app $GITHUB_WORKSPACE
         xattr -cr AppiumForMac.app
         zip -r Debug_AppiumForMac.zip AppiumForMac.app
-    - name: Upload the AppiumForMac.app
-      uses: actions/upload-artifact@v2
-      with:
-        name: Debug_AppiumForMac
-        path: Debug_AppiumForMac.zip
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           Changes in this Release:
           - Please update items included in this release
         draft: true
-        prerelease: false
+        prerelease: true
     - name: Upload Debug_AppiumForMac
       id: upload-release-asset
       uses: actions/upload-release-asset@v1

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Newer macOS requires 64 bit binary.
 You can build this repository manually to match for your environment with Xcode.
 Then, please copy `AppiumForMac.app` in  `/Users/<username>/Library/Developer/Xcode/DerivedData/AppiumForMac-xxxxxxxx/Build/Products/Debug/AppiumForMac.app` to `/Applications`.
 
-## Download binaries built on CI
+## Release
+
+Please push a tag with `v` prefix like `v0.5.0`.
+Then, a GitHub Actions will push a new `AppiumForMac.app` as the version as a draft on [Release page](https://github.com/appium/appium-for-mac/releases).
+Once you convert the draft to publish, the tag will appear on the release page.
+
+### Download binaries built on CI
 
 [Release page](https://github.com/appium/appium-for-mac/releases) provides `AppiumForMac.app` for each tag.
 You also can get the latest `AppiumForMac.app` on each PR.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The WebDriver server is on port 4622. If you build it yourself, you can change t
 
 ## Requirements
 * Running: Mac OS X 10.7 or later.
-* Building: Xcode 7.2.1 or later. 
+* Building: Xcode 7.2.1 or later.
 
 ## Installation
 Mac OS X does not allow an application to use the Accessibility API without permission, so you have to enable it manually.
@@ -32,6 +32,15 @@ Mac OS X does not allow an application to use the Accessibility API without perm
 Newer macOS requires 64 bit binary.
 You can build this repository manually to match for your environment with Xcode.
 Then, please copy `AppiumForMac.app` in  `/Users/<username>/Library/Developer/Xcode/DerivedData/AppiumForMac-xxxxxxxx/Build/Products/Debug/AppiumForMac.app` to `/Applications`.
+
+## Download binaries built on CI
+
+[Release page](https://github.com/appium/appium-for-mac/releases) provides `AppiumForMac.app` for each tag.
+You also can get the latest `AppiumForMac.app` on each PR.
+
+If you could not start `AppiumForMac.app` by security limitation by macOS,
+please try out `xattr -cr /path/to/AppiumForMac.app` command once to remove extende attributes on macOS.
+Then, you probably open the `AppiumForMac.app` without error.
 
 ## New Features For Scripters (as of April 2017)
 
@@ -116,7 +125,7 @@ Bad examples:
 
 
 ### Automatic AXPath Recording
-Generating an AXPath for an element is easy: while AppiumForMac is running, just use the mouse to point to an element, then press the fn (function) key for a couple of seconds. AppiumForMac will build the AXPath of the element on screen, and copy it to the clipboard. You can then paste it into your script. 
+Generating an AXPath for an element is easy: while AppiumForMac is running, just use the mouse to point to an element, then press the fn (function) key for a couple of seconds. AppiumForMac will build the AXPath of the element on screen, and copy it to the clipboard. You can then paste it into your script.
 
 ### Session Kill Switch
 If your script has gone off the rails, you need to stop it. But if a script is running, it can keep typing and clicking as you try to cancel it. Now, while a session is in progress, you can press the fn (function) key for a couple of seconds. AppiumForMac will cancel any open sessions. Your script will receive a "no such session" error.
@@ -127,19 +136,19 @@ AppiumForMac sessions have several new properties. See below for a description o
 #### Getting and Setting Properties with a Cookie
 Each cookie is a dictionary with at least two keys: 'name' and 'value'. The Selenium commands are: get_cookies, get_cookie(), and addCookie().
 
-1. To get all cookies, use driver.get_cookies(). This will return an array of cookie dictionaries. 
+1. To get all cookies, use driver.get_cookies(). This will return an array of cookie dictionaries.
 1. To get one cookie, use driver.get_cookie('cookieName'). This will return the cookie with the name 'cookieName'.
 1. To set a cookie, use driver.add_cookie({'name': 'cookieName', 'value': 'cookieValue'}).
 
 #### Implicit Timeouts
 AppiumForMac supports standard implicit timeouts when finding an element. The default is 0.0 seconds, that is, there will be only one attempt.
 
-    For example, to set a 20.5 second timeout, use driver.add_cookie({'name': 'implicit_timeout', 'value': 20.5}). 
+    For example, to set a 20.5 second timeout, use driver.add_cookie({'name': 'implicit_timeout', 'value': 20.5}).
 
 #### Loop Delay
 During an implicit timeout to find an element, you can specify how long to wait between attempts. The default is 1.0 seconds. The loop delay occurs _after_ each attempt, so if the element is found on the first attempt, there will be no delay. The total waiting time will not exceed implicit_timeout, regardless of the loop_delay value.
 
-    For example, to set a 1.7 second loop delay, use driver.add_cookie({'name': 'loop_delay', 'value': 1.7}). 
+    For example, to set a 1.7 second loop delay, use driver.add_cookie({'name': 'loop_delay', 'value': 1.7}).
 
 #### Command Delay
 This provides a simple way to slow down a script if needed, e.g. for debugging. It specifies an arbitrary delay _before_ each command. The default is 0.0 seconds so your script runs at full speed!
@@ -176,7 +185,7 @@ The name of each handler is dynamically constructed from the http request. All y
 #### Creating a new command handler
 
 1. Go to AfMHandlers.m.
-1. Find an existing handler method. You might want to find one that is similar to the new command you want to add. 
+1. Find an existing handler method. You might want to find one that is similar to the new command you want to add.
 1. Copy the handler method to the clipboard.
 1. Find the commented out stub for the new handler method and paste at that location.
 1. Rename your new handler, following the naming pattern for the other handlers.


### PR DESCRIPTION
The release flow succeeded, but the downloaded image was not used.
(No logic changes after https://github.com/appium/appium-for-mac/pull/93#issuecomment-660496414 though...)

~~Let me tweak it...~~ <= I found `xattr -cr /path/to/AppiumForMac.app` may help to avoid this error. This command must run on the user side environment. so, I addressed this tip in the readme.

![image](https://user-images.githubusercontent.com/5511591/87865764-e82fd800-c9b3-11ea-8c40-d0f8c40df3cb.png)
