### PR TITLE
Allow Appium to Scroll To a particular element on screen

### DIFF
--- a/AppiumForMac/Server/Controller/AfMSessionController.h
+++ b/AppiumForMac/Server/Controller/AfMSessionController.h
@@ -154,6 +154,7 @@ extern NSString * const kCookieDiagnosticsDirectory;
 -(GDataXMLDocument*)xmlPageSource;
 -(GDataXMLDocument*)xmlPageSourceFromRootUIElement:(PFUIElement*)rootUIElement pathMap:(NSMutableDictionary*)pathMap xPath:(NSString*)xPath;
 - (NSArray *)findAllUsingAbsoluteAXPath:(NSString *)path;
+-(BOOL) scrollPage : (id)element;
 
 - (AppiumMacHTTPJSONResponse *)executeWebDriverCommandWithPath:(NSString*)path data:(NSData*)postData onMainThread:(BOOL)onMainThread commandBlock:(AppiumMacHTTPJSONResponse *(^)(AfMSessionController *session, NSDictionary *commandParams, int *statusCode))commandBlock;
 

--- a/AppiumForMac/Server/Controller/AfMSessionController.m
+++ b/AppiumForMac/Server/Controller/AfMSessionController.m
@@ -891,6 +891,55 @@ const NSTimeInterval kModifierPause = 0.05;
 	return [windows objectAtIndex:windowIndex];
 }
 
+-(BOOL) scrollPage:(id)element
+{
+    float increment_by = 0.25;
+    bool scroll_found = false;
+    PFUIElement* scroll;
+    float axValue = 0,adder = 0;
+
+    id parent = [(PFUIElement*)element AXParent];
+    NSArray* siblings = [parent AXChildren];
+
+    while(scroll == nil && parent != nil)
+    {
+        for(id child in siblings)
+        {
+            if([[(PFUIElement*)child AXRole] isEqualToString:@"AXScrollBar"])
+            {
+                scroll = child;
+                scroll_found = true;
+                break;
+            }
+        }
+
+        parent = [(PFUIElement*)parent AXParent];
+        siblings = [parent AXChildren];
+    }
+
+    NSPoint middlePoint = [[element AXPosition] pointValue];
+    if(middlePoint.y < 0)
+    {
+
+    }
+
+    if(scroll_found)
+    {
+        while(adder<=1)
+        {
+            axValue = [scroll.AXValue floatValue];
+            adder = axValue + increment_by;
+            scroll.AXValue = [NSNumber numberWithFloat: adder];
+
+            if([self isElementDisplayed:element])
+            {
+                return YES;
+            }
+        }
+    }
+    return NO;
+}
+
 -(GDataXMLDocument*)xmlPageSource
 {
 	return [self xmlPageSourceFromRootUIElement:nil pathMap:nil xPath:nil];

--- a/AppiumForMac/Server/Handlers/AfMHandlers.h
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.h
@@ -179,6 +179,9 @@
 // POST /session/:sessionId/doubleclick
 - (AppiumMacHTTPJSONResponse *)post_doubleclick:(NSString*)path data:(NSData *)postData;
 
+// POST /session/:sessionId/element/:id/scrollTo
+- (AppiumMacHTTPJSONResponse *)post_element_scrollTo:(NSString*)path data:(NSData*)postData;
+
 // POST /session/:sessionId/touch/click
 // POST /session/:sessionId/touch/down
 // POST /session/:sessionId/touch/up

--- a/AppiumForMac/Server/Handlers/AfMHandlers.m
+++ b/AppiumForMac/Server/Handlers/AfMHandlers.m
@@ -963,6 +963,28 @@
     }];
 }
 
+
+// POST /session/:sessionId/element/:id/scrollTo
+// Scroll to the particular element passed to Appium. Scrolls till the bottom of the screen till the element becomes visible
+// If the element is still not visible returns element not found
+- (AppiumMacHTTPJSONResponse *)post_element_scrollTo:(NSString *)path data:(NSData *)postData
+{
+    return [self executeWebDriverCommandWithPath:path data:nil onMainThread:YES commandBlock:^(AfMSessionController *session, NSDictionary *commandParams, int *statusCode)
+            {
+                id element = [commandParams objectForKey:@"elementObject"];
+
+                if ([session isElementDisplayed:element]) {
+                    return [AppiumMacHTTPJSONResponse responseWithJson:nil status:kAfMStatusCodeSuccess session:session.sessionId];
+                }
+
+                BOOL result = [session scrollPage:element];
+
+                return result ? [AppiumMacHTTPJSONResponse responseWithJson:nil status:kAfMStatusCodeSuccess session:session.sessionId] :
+                [AppiumMacHTTPJSONResponse responseWithJsonError:kAfMStatusCodeNoSuchElement session:session.sessionId];
+            }];
+}
+
+
 // POST /session/:sessionId/touch/click
 // Single tap on the touch enabled device.
 


### PR DESCRIPTION
Adding Scroll To functionality which will help OSX Applications to scroll to a particular element.
The code increments the scroll bar and checks if the passed on element is visible.