### PR TITLE
Add partial xpath support to ignore identifiers in the axpath

### DIFF
--- a/AppiumForMac/Server/Controller/AfMSessionController.h
+++ b/AppiumForMac/Server/Controller/AfMSessionController.h
@@ -155,6 +155,8 @@ extern NSString * const kCookieDiagnosticsDirectory;
 -(GDataXMLDocument*)xmlPageSourceFromRootUIElement:(PFUIElement*)rootUIElement pathMap:(NSMutableDictionary*)pathMap xPath:(NSString*)xPath;
 - (NSArray *)findAllUsingAbsoluteAXPath:(NSString *)path;
 
+-(PFUIElement*) findElementRecursively:(PFUIElement *)rootUIElement calls:(int)calls;
+
 - (AppiumMacHTTPJSONResponse *)executeWebDriverCommandWithPath:(NSString*)path data:(NSData*)postData onMainThread:(BOOL)onMainThread commandBlock:(AppiumMacHTTPJSONResponse *(^)(AfMSessionController *session, NSDictionary *commandParams, int *statusCode))commandBlock;
 
 - (void)setDesiredCapabilities:(NSDictionary *)desiredCapabilities;


### PR DESCRIPTION
In the desktop application we have, the AXIdentifier part keeps changing and this results in test case failures. 
Adding partial xpath support which will ignore the identifiers and will search for the element recursively